### PR TITLE
Fix error if empty headers

### DIFF
--- a/lib/matter_compiler/blueprint.rb
+++ b/lib/matter_compiler/blueprint.rb
@@ -76,6 +76,10 @@ module MatterCompiler
       return if ast.empty?
       @collection = Array.new
       ast.each do |item|
+        if item.has_key?("Authorization")
+          item[:name] = "Authorization"
+          item[:value] = item['Authorization']
+        end
         unless item.empty?
           @collection << Hash[item[:name].to_sym, item[:value]]
         end

--- a/lib/matter_compiler/blueprint.rb
+++ b/lib/matter_compiler/blueprint.rb
@@ -76,7 +76,9 @@ module MatterCompiler
       return if ast.empty?
       @collection = Array.new
       ast.each do |item|
-        @collection << Hash[item[:name].to_sym, item[:value]]
+        unless item.empty?
+          @collection << Hash[item[:name].to_sym, item[:value]]
+        end
       end
     end
 

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -20,6 +20,12 @@ class HeadersTest < Minitest::Test
     }    
   ]
 
+  AST_HASH_AUTH_LEGACY = [
+    {
+      "Authorization" => "****token****"
+    }
+  ]
+
   BLUEPRINT = \
 %Q{+ Headers
 
@@ -64,6 +70,13 @@ class HeadersTest < Minitest::Test
     assert_equal "text/plain", headers.collection[1][:'Content-Type']
 
     assert_equal "text/plain", headers.content_type    
+  end
+
+  def test_legacy_headers
+    headers = headers = MatterCompiler::Headers.new(HeadersTest::AST_HASH_AUTH_LEGACY)
+    assert_equal 1, headers.collection.length
+    assert_equal :'Authorization', headers.collection[0].keys[0]
+    assert_equal '****token****', headers.collection[0][:'Authorization']
   end
 
   def test_serialize

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -22,6 +22,10 @@ class MetadataTest < Minitest::Test
     assert_equal "1A", metadata.collection[0][:FORMAT]
   end
 
+  def test_empty_metadata
+    metadata = MatterCompiler::Metadata.new([{}])
+  end
+
   def test_serialize
     metadata = MatterCompiler::Metadata.new(MetadataTest::AST_HASH)
     assert_equal MetadataTest::BLUEPRINT, metadata.serialize

--- a/test/metadata_test.rb
+++ b/test/metadata_test.rb
@@ -24,6 +24,7 @@ class MetadataTest < Minitest::Test
 
   def test_empty_metadata
     metadata = MatterCompiler::Metadata.new([{}])
+    assert_equal 0, metadata.collection.length
   end
 
   def test_serialize


### PR DESCRIPTION
```
/app/vendor/bundle/ruby/2.1.0/gems/matter_compiler-0.5.1/lib/matter_compiler/blueprint.rb:79:in `[]': no implicit conversion of Symbol into Integer (TypeError)  
```